### PR TITLE
Bug: Refactor headers to fix overlapping elements

### DIFF
--- a/table-of-contents-style-homepage/about.css
+++ b/table-of-contents-style-homepage/about.css
@@ -6,10 +6,6 @@ main {
   columns: auto;
 }
 
-.find-my-city:hover {
-  color: white;
-}
-
 .about-container {
 	display: flex;
 	margin: 2.25rem 3.5rem 0 3.5rem;
@@ -165,15 +161,6 @@ textarea {
 /* begin mobile styles */
   
 @media screen and (max-width: 640px) {
-
-  #search {
-    margin-right: 1.5rem;
-  }
-
-  .search {
-    margin: 1.5rem 0 0;
-    right: 1.5rem;
-  }
 
   .about-container {
     margin: 1.75rem 2rem 0 2rem;

--- a/table-of-contents-style-homepage/about.html
+++ b/table-of-contents-style-homepage/about.html
@@ -27,33 +27,37 @@
 <body>
 	<div class="container">
 		<header class="desktop-header">
-			<div class="homepage-link">
-				<a href="index.html">
-				<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-				<h1 class="little-help-book">Little Help Book</h1>    
-				</a>
-			</div>
-			<div class="description menu-icon">Human Services Resource Directory</div>
-            <div class="find-help menu-icon">Find help in</div>
+				<div class="branding">
+					<a class="homepage-link" href="index.html">
+						<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+						<h1 class="little-help-book">Little Help Book</h1>    
+					</a>
+				</div>
 
-			<!-- the new Find my City element is here but the script needed for it to work isn't hooked up -->
-            <div class="breadcrumb-box">
-                <select class="breadcrumb city menu-icon" id="citySelect">
-                    <option value="">Lane County, Oregon</option>
-                </select>
-            </div>
+				<div class="description menu-icon">Human Services Resource Directory</div>
 
-				<button class="spanish menu-button menu-icon">Español</button>
-				<button class="about menu-button menu-icon">About</button>
-			<div class="search">
-					<div class="menu-lines">
-					<div class="hamburger"></div>
-					<div class="hamburger"></div>
-					<div class="hamburger"></div>        
-					</div>
-					<input type="image" src="search-line.png" class="search-input" type="search">
-			</div>
+				<!-- the new Find my City element is here but the script needed for it to work isn't hooked up -->
+				<div class="breadcrumb-box">
+						<div class="find-help menu-icon">Find help in</div>
+						<select class="breadcrumb city menu-icon" id="citySelect">
+								<option value="">Lane County, Oregon</option>
+						</select>
+				</div>
+
+				<nav class="header-nav">
+						<button class="header-nav-item spanish menu-button menu-icon">Español</button>
+						<button class="header-nav-item about menu-button menu-icon">About</button>
+						<div class="header-nav-item menu-lines">
+								<div class="hamburger"></div>
+								<div class="hamburger"></div>
+								<div class="hamburger"></div>        
+						</div>
+						<div class="header-nav-item search">
+								<input type="image" src="search-line.png" class="search-input" type="search">
+						</div>
+				</nav>
 		</header>
+
 		<main class="about-container">
 		<section class="left-side">
 			<div class="about-content">
@@ -133,21 +137,25 @@
 	</div>
 
 	<div class="mobile-container" id="mobile-container">
-		<header class="logo-title black-top">
-				<img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-				<h1 class="little-help-book">Little Help Book</h1>
-				<div id="search">
-						<div class="search">
-								<div class="menu-lines">
-								<div class="hamburger"></div>
-								<div class="hamburger"></div>
-								<div class="hamburger"></div>        
-								</div>
-								<input type="image" src="search-line.png" class="search-input" type="search">
-						</div>
-				</div>
-		</header>
-</div>
+			<header class="mobile-header">
+					<div class="branding">
+							<a class="homepage-link" href="index.html">
+									<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+									<h1 class="little-help-book">Little Help Book</h1>
+							</a>
+					</div>
+					<nav class="header-nav">
+							<div class="header-nav-item menu-lines">
+									<div class="hamburger"></div>
+									<div class="hamburger"></div>
+									<div class="hamburger"></div>
+							</div>
+							<div class="header-nav-item search">
+									<input type="image" src="search-line.png" class="search-input" type="search">
+							</div>
+					</nav>
+			</header>
+	</div>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 <script type="text/javascript" src="homepage.js"></script>
 <script type="text/javascript" src="src/NavBreadcrumb.js"></script>

--- a/table-of-contents-style-homepage/category.css
+++ b/table-of-contents-style-homepage/category.css
@@ -201,6 +201,12 @@ option {
 
 /* responsive transition to tablet */
 
+@media screen and (min-width: 1175px) {
+  .menu-lines {
+    display: block;
+  }
+}
+
 @media screen and (max-width: 1056px) {
 
   .mobile-container {

--- a/table-of-contents-style-homepage/category.css
+++ b/table-of-contents-style-homepage/category.css
@@ -21,20 +21,6 @@ option {
   font-size: 1rem;
 }
 
-.menu-lines {
-  margin-left: -0.5rem;
-  margin-right: 1rem;
-  margin-top: -0.1rem;
-}
-
-.hamburger {
-  width: 35px;
-  height: 6px;
-  background-color: rgb(126, 126, 126);
-  border-radius: 2.5px;
-  margin: 5.5px 0 0 10.5px;
-}
-
 .inner-container {
   display: flex;
   background-color: #f5f5f5;
@@ -50,10 +36,6 @@ option {
   font-size: 2rem;
   font-weight: bold;
   white-space: nowrap;
-}
-
-input {
-  margin: 0 .2rem 0 0;
 }
 
 .subcategory-buttons {

--- a/table-of-contents-style-homepage/category.css
+++ b/table-of-contents-style-homepage/category.css
@@ -11,10 +11,6 @@ main {
   margin-bottom: 0;
 }
 
-.breadcrumb-box {
-  margin-left: 20rem;
-}
-
 .breadcrumb {
   width: 16.8rem;
 }
@@ -80,10 +76,6 @@ input {
   font-size: 2rem;
   font-family: serif;
   margin: .3rem .5rem 0 -1.7rem;
-}
-
-.search {
-  display: flex;
 }
 
 .nav-buttons {
@@ -295,15 +287,6 @@ input {
   /* begin mobile styles */
   
 @media screen and (max-width: 640px) {
-
-  #search {
-    margin-right: 1.5rem;
-  }
-
-  .search {
-    margin: 1.5rem 0 0;
-    right: 1.5rem;
-  }
 
   .left-column, .right-column {
     margin-left: 2rem;

--- a/table-of-contents-style-homepage/category.html
+++ b/table-of-contents-style-homepage/category.html
@@ -36,10 +36,13 @@
 <body>
     <div class="page-container">
         <header class="desktop-header">
-            <div> <a href="index.html">
-                <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="66px" height="66px">
-                <h1 class="little-help-book">Little Help Book</h1> </a>
-            </div>
+        	<div class="branding">
+				<a class="homepage-link" href="index.html">
+					<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+					<h1 class="little-help-book">Little Help Book</h1>    
+				</a>
+			</div>
+
             <div class="breadcrumb-box">
                 <select class="breadcrumb city" id="citySelect">
                     <option value=""><em>Loading...</em></option>
@@ -52,16 +55,16 @@
                 </select>
             </div>
     
-            <div class="search">
-                <a href="about.html">
+            <nav class="header-nav">
                 <div class="menu-lines">
                   <div class="hamburger"></div>
                   <div class="hamburger"></div>
                   <div class="hamburger"></div>
                 </div>
-                </a>
-                <input type="image" src="search-line.png" class="search-input" type="search">
-            </div>
+                <div class="header-nav-item search">
+                    <input type="image" src="search-line.png" class="search-input" type="search">
+                </div>
+            </nav>
         </header>
 
             <div class="inner-container">
@@ -135,21 +138,23 @@
     </div>
 
     <div class="mobile-container" id="mobile-container">
-        <header class="logo-title black-top">
-            <img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-            <h1 class="little-help-book">Little Help Book</h1>
-            <div id="search">
-                <div class="search">
-                    <a href="about.html">
-                    <div class="menu-lines">
+        <header class="mobile-header">
+            <div class="branding">
+                <a class="homepage-link" href="index.html">
+                        <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                        <h1 class="little-help-book">Little Help Book</h1>
+                </a>
+            </div>
+            <nav class="header-nav">
+                <div class="header-nav-item menu-lines">
                     <div class="hamburger"></div>
                     <div class="hamburger"></div>
-                    <div class="hamburger"></div>        
-                    </div>
-                    </a>
+                    <div class="hamburger"></div>
+                </div>
+                <div class="header-nav-item search">
                     <input type="image" src="search-line.png" class="search-input" type="search">
                 </div>
-            </div>
+            </nav>
         </header>
     </div>
 <script type="text/javascript" src="src/map.js"></script>

--- a/table-of-contents-style-homepage/category.html
+++ b/table-of-contents-style-homepage/category.html
@@ -56,11 +56,13 @@
             </div>
     
             <nav class="header-nav">
-                <div class="menu-lines">
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>
-                </div>
+                <a class="header-nav-item">
+                    <div class="menu-lines">
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                    </div>
+                </a>
                 <div class="header-nav-item search">
                     <input type="image" src="search-line.png" class="search-input" type="search">
                 </div>
@@ -141,8 +143,8 @@
         <header class="mobile-header">
             <div class="branding">
                 <a class="homepage-link" href="index.html">
-                        <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-                        <h1 class="little-help-book">Little Help Book</h1>
+                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                    <h1 class="little-help-book">Little Help Book</h1>
                 </a>
             </div>
             <nav class="header-nav">

--- a/table-of-contents-style-homepage/emergency.html
+++ b/table-of-contents-style-homepage/emergency.html
@@ -28,14 +28,17 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/2.0.0/handlebars.js"></script>
     <script rel="text/javascript" src="src/airtable.browser.js"></script>
     <script rel="text/javascript" src="src/dal.js"></script>
-</head >
+</head>
 <body>
     <div class="page-container">
         <header class="desktop-header">
-            <div> <a href="index.html">
-                <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="66px" height="66px">
-                <h1 class="little-help-book">Little Help Book</h1> </a>
+            <div class="branding">
+                <a class="homepage-link" href="index.html">
+                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                    <h1 class="little-help-book">Little Help Book</h1>    
+                </a>
             </div>
+
             <div class="breadcrumb-box">
                 <select class="breadcrumb city" id="citySelect">
                     <option value=""><em>Loading...</em></option>
@@ -48,34 +51,38 @@
                 </select>
             </div>
     
-            <div class="search">
-                <a href="about.html">
-                <div class="menu-lines">
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>
-                </div>
+            <nav class="header-nav">
+                <a class="header-nav-item">
+                    <div class="menu-lines">
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                    </div>
                 </a>
-                <input type="image" src="search-line.png" class="search-input" type="search">
-            </div>
+                <div class="header-nav-item search">
+                    <input type="image" src="search-line.png" class="search-input" type="search">
+                </div>
+            </nav>
         </header>
 
         <div class="mobile-container" id="mobile-container">
-            <header class="logo-title black-top">
-                <img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-                <h1 class="little-help-book">Little Help Book</h1>
-                <div id="search">
-                    <div class="search">
-                        <a href="about.html">
-                        <div class="menu-lines">
+            <header class="mobile-header">
+                <div class="branding">
+                    <a class="homepage-link" href="index.html">
+                        <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                        <h1 class="little-help-book">Little Help Book</h1>
+                    </a>
+                </div>
+                <nav class="header-nav">
+                    <div class="header-nav-item menu-lines">
                         <div class="hamburger"></div>
                         <div class="hamburger"></div>
-                        <div class="hamburger"></div>        
-                        </div>
-                        </a>
+                        <div class="hamburger"></div>
+                    </div>
+                    <div class="header-nav-item search">
                         <input type="image" src="search-line.png" class="search-input" type="search">
                     </div>
-                </div>
+                </nav>
             </header>
         </div>
 

--- a/table-of-contents-style-homepage/index.html
+++ b/table-of-contents-style-homepage/index.html
@@ -26,7 +26,7 @@
     <div class="container">
         <!-- It would help to refactor this into a reusable header include -->
         <header class="desktop-header">
-            <a class="homepage-link">
+            <a class="homepage-link" href="index.html">
                 <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
                 <h1 class="little-help-book">Little Help Book</h1>
             </a>
@@ -45,14 +45,14 @@
             <nav class="header-nav">
                 <button class="header-nav-item spanish menu-button menu-icon">Español</button>
                 <button class="header-nav-item about menu-button menu-icon"><a class="about" href="about.html">About</a></button>
+                <a class="header-nav-item" href="#">
+                    <div class="menu-lines">
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                    </div>
+                </a>
                 <div class="header-nav-item search">
-                    <a href="about.html">
-                        <div class="menu-lines">
-                            <div class="hamburger"></div>
-                            <div class="hamburger"></div>
-                            <div class="hamburger"></div>
-                        </div>
-                    </a>
                     <input type="image" src="search-line.png" class="search-input" type="search">
                 </div>
             </nav>
@@ -116,18 +116,22 @@
     </div>
 
     <div class="mobile-container" id="mobile-container">
-        <header class="logo-title">
-            <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-            <h1 class="little-help-book">Little Help Book</h1>
+        <header class="mobile-header">
+            <div clas="branding">
+                <a class="homepage-link">
+                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                    <h1 class="little-help-book">Little Help Book</h1>
+                </a>
+            </div>
         </header>
-            <main class="content-container">
-                <div class="people-care">People care.</div>
-                <h3 class="find-help-in-lane">Find help in Lane County, Oregon. Available by phone or in person.</h3>
-                <div class="buttons">
-                    <button class="help-button" id="help-button">Find Help</button>
-                    <button class="spanish-button">Español</button>
-                </div>
-            </main>
+        <main class="content-container">
+            <div class="people-care">People care.</div>
+            <h3 class="find-help-in-lane">Find help in Lane County, Oregon. Available by phone or in person.</h3>
+            <div class="buttons">
+                <button class="help-button" id="help-button">Find Help</button>
+                <button class="spanish-button">Español</button>
+            </div>
+        </main>
         <footer>Human service resource guide powered by <h2 class="bold-inline h123-reset">White Bird Clinic</h2></footer>
     </div>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>

--- a/table-of-contents-style-homepage/index.html
+++ b/table-of-contents-style-homepage/index.html
@@ -116,14 +116,24 @@
     </div>
 
     <div class="mobile-container" id="mobile-container">
-        <header class="mobile-header">
-            <div clas="branding">
-                <a class="homepage-link">
-                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-                    <h1 class="little-help-book">Little Help Book</h1>
-                </a>
-            </div>
-        </header>
+			<header class="mobile-header">
+					<div class="branding">
+							<a class="homepage-link" href="index.html">
+									<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+									<h1 class="little-help-book">Little Help Book</h1>
+							</a>
+					</div>
+					<nav class="header-nav">
+							<div class="header-nav-item menu-lines">
+									<div class="hamburger"></div>
+									<div class="hamburger"></div>
+									<div class="hamburger"></div>
+							</div>
+							<div class="header-nav-item search">
+									<input type="image" src="search-line.png" class="search-input" type="search">
+							</div>
+					</nav>
+			</header>
         <main class="content-container">
             <div class="people-care">People care.</div>
             <h3 class="find-help-in-lane">Find help in Lane County, Oregon. Available by phone or in person.</h3>

--- a/table-of-contents-style-homepage/index.html
+++ b/table-of-contents-style-homepage/index.html
@@ -117,9 +117,8 @@
 
     <div class="mobile-container" id="mobile-container">
         <header class="logo-title">
-            <img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+            <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
             <h1 class="little-help-book">Little Help Book</h1>
-            <div class="black-top"></div>
         </header>
             <main class="content-container">
                 <div class="people-care">People care.</div>

--- a/table-of-contents-style-homepage/index.html
+++ b/table-of-contents-style-homepage/index.html
@@ -24,37 +24,38 @@
 </head>
 <body>
     <div class="container">
+        <!-- It would help to refactor this into a reusable header include -->
         <header class="desktop-header">
-            <div class="homepage-link">
-                <a href="index.html">
-                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-                    <h1 class="little-help-book">Little Help Book</h1>
-                </a>
-            </div>
+            <a class="homepage-link">
+                <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                <h1 class="little-help-book">Little Help Book</h1>
+            </a>
 
             <div class="description menu-icon">Human Services Resource Directory</div>
-            <div class="find-help menu-icon">Find help in</div>
 
             <!-- Gets filled dynamically -->
             <div class="breadcrumb-box">
+                <div class="find-help menu-icon">Find help in</div>
                 <select class="breadcrumb city menu-icon" id="citySelect">
                     <option value=""><em>Loading...</em></option>
                     <option value="">Lane County, Oregon</option>
                 </select>
             </div>
 
-            <button class="spanish menu-button menu-icon">Español</button>
-            <button class="about menu-button menu-icon"><a class="about" href="about.html">About</a></button>
-            <div class="search">
-                <a href="about.html">
-                    <div class="menu-lines">
-                        <div class="hamburger"></div>
-                        <div class="hamburger"></div>
-                        <div class="hamburger"></div>
-                    </div>
-                </a>
-                <input type="image" src="search-line.png" class="search-input" type="search">
-            </div>
+            <nav class="header-nav">
+                <button class="header-nav-item spanish menu-button menu-icon">Español</button>
+                <button class="header-nav-item about menu-button menu-icon"><a class="about" href="about.html">About</a></button>
+                <div class="header-nav-item search">
+                    <a href="about.html">
+                        <div class="menu-lines">
+                            <div class="hamburger"></div>
+                            <div class="hamburger"></div>
+                            <div class="hamburger"></div>
+                        </div>
+                    </a>
+                    <input type="image" src="search-line.png" class="search-input" type="search">
+                </div>
+            </nav>
         </header>
 
         <!-- Main will be filled with data from the database, formatted as specified in the handlebars template below. -->

--- a/table-of-contents-style-homepage/provider.css
+++ b/table-of-contents-style-homepage/provider.css
@@ -3,10 +3,6 @@ a {
   color: black;
 }
 
-.breadcrumb-box {
-  margin-left: 20rem;
-}
-
 .breadcrumb {
   width: 16.8rem;
 }
@@ -15,24 +11,6 @@ option {
   background-color: white;
   color: black;
   font-size: 1rem;
-}
-
-.search {
-  display: flex;
-}
-
-.menu-lines {
-  margin-left: -0.5rem;
-  margin-right: 1rem;
-  margin-top: -0.1rem;
-}
-
-.hamburger {
-  width: 35px;
-  height: 6px;
-  background-color: rgb(126, 126, 126);
-  border-radius: 2.5px;
-  margin: 5.5px 0 0 10.5px;
 }
 
 .provider-page {
@@ -133,6 +111,12 @@ option {
 
 /* responsive transition to tablet */
 
+@media screen and (min-width: 1175px) {
+  .menu-lines {
+    display: block;
+  }
+}
+
 @media screen and (max-width: 1056px) {
 
   .mobile-container {
@@ -146,12 +130,6 @@ option {
   body {
     display: flex;
     flex-direction: column-reverse;
-  }
-
-  #search {
-    display: flex;
-    justify-content: right;
-    margin-right: 2.5rem;
   }
 
   .provider-page {
@@ -179,18 +157,9 @@ option {
   }
 }
   
-  /* begin mobile styles */
+/* begin mobile styles */
   
-  @media screen and (max-width: 640px) {
-
-  #search {
-    margin-right: 1.5rem;
-  }
-
-  .search {
-    margin: 1.5rem 0 0;
-    right: 1.5rem;
-  }
+@media screen and (max-width: 640px) {
 
   .provider-page {
     padding: 0 2rem;

--- a/table-of-contents-style-homepage/provider.html
+++ b/table-of-contents-style-homepage/provider.html
@@ -37,13 +37,14 @@
 
     <div class="page-container">
 
-        <header class="desktop-header">
-            <div> <a href="index.html">
-                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="66px"
-                        height="66px">
-                    <h1 class="little-help-book">Little Help Book</h1>
-                </a>
-            </div>
+         <header class="desktop-header">
+        	<div class="branding">
+				<a class="homepage-link" href="index.html">
+					<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+					<h1 class="little-help-book">Little Help Book</h1>    
+				</a>
+			</div>
+
             <div class="breadcrumb-box">
                 <select class="breadcrumb city" id="citySelect">
                     <option value=""><em>Loading...</em></option>
@@ -55,18 +56,19 @@
                     <option value=""><em>Loading...</em></option>
                 </select>
             </div>
-
-            <div class="search">
-                <a href="about.html">
+    
+            <nav class="header-nav">
+                <a class="header-nav-item">
                     <div class="menu-lines">
                         <div class="hamburger"></div>
                         <div class="hamburger"></div>
                         <div class="hamburger"></div>
                     </div>
                 </a>
-                <input type="image" src="search-line.png" class="search-input" type="search">
-            </div>
-
+                <div class="header-nav-item search">
+                    <input type="image" src="search-line.png" class="search-input" type="search">
+                </div>
+            </nav>
         </header>
 
         <section class="provider-page">
@@ -121,21 +123,23 @@
     </div>
 
     <div class="mobile-container" id="mobile-container">
-        <header class="logo-title black-top">
-            <img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-            <h1 class="little-help-book">Little Help Book</h1>
-            <div id="search">
-                <div class="search">
-                    <a href="about.html">
-                        <div class="menu-lines">
-                            <div class="hamburger"></div>
-                            <div class="hamburger"></div>
-                            <div class="hamburger"></div>
-                        </div>
-                    </a>
+        <header class="mobile-header">
+            <div class="branding">
+                <a class="homepage-link" href="index.html">
+                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                    <h1 class="little-help-book">Little Help Book</h1>
+                </a>
+            </div>
+            <nav class="header-nav">
+                <div class="header-nav-item menu-lines">
+                    <div class="hamburger"></div>
+                    <div class="hamburger"></div>
+                    <div class="hamburger"></div>
+                </div>
+                <div class="header-nav-item search">
                     <input type="image" src="search-line.png" class="search-input" type="search">
                 </div>
-            </div>
+            </nav>
         </header>
     </div>
 

--- a/table-of-contents-style-homepage/providers.html
+++ b/table-of-contents-style-homepage/providers.html
@@ -26,11 +26,14 @@
 </head>
 <body>
     <div class="container">
-        <header class="desktop-header">
-            <div> <a href="index.html">
-                <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="66px" height="66px">
-                <h1 class="little-help-book">Little Help Book</h1> </a>
-            </div>
+         <header class="desktop-header">
+        	<div class="branding">
+				<a class="homepage-link" href="index.html">
+					<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+					<h1 class="little-help-book">Little Help Book</h1>    
+				</a>
+			</div>
+
             <div class="breadcrumb-box">
                 <select class="breadcrumb city" id="citySelect">
                     <option value=""><em>Loading...</em></option>
@@ -43,16 +46,18 @@
                 </select>
             </div>
     
-            <div class="search">
-                <a href="about.html">
-                <div class="menu-lines">
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>        
-                </div>
+            <nav class="header-nav">
+                <a class="header-nav-item">
+                    <div class="menu-lines">
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                    </div>
                 </a>
-                <input type="image" src="search-line.png" class="search-input" type="search">
-            </div>
+                <div class="header-nav-item search">
+                    <input type="image" src="search-line.png" class="search-input" type="search">
+                </div>
+            </nav>
         </header>
 
         <main id="main">
@@ -278,12 +283,24 @@
     </div>
 
     <div class="mobile-container" id="mobile-container">
-        <header class="logo-title">
-            <img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-            <h1 class="little-help-book">Little Help Book</h1>
-            <div class="black-top"></div>
+        <header class="mobile-header">
+            <div class="branding">
+                <a class="homepage-link" href="index.html">
+                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                    <h1 class="little-help-book">Little Help Book</h1>
+                </a>
+            </div>
+            <nav class="header-nav">
+                <div class="header-nav-item menu-lines">
+                    <div class="hamburger"></div>
+                    <div class="hamburger"></div>
+                    <div class="hamburger"></div>
+                </div>
+                <div class="header-nav-item search">
+                    <input type="image" src="search-line.png" class="search-input" type="search">
+                </div>
+            </nav>
         </header>
-
 
         <div class="alphabetical-listing-mobile">
 

--- a/table-of-contents-style-homepage/styles.css
+++ b/table-of-contents-style-homepage/styles.css
@@ -52,7 +52,7 @@ select:hover {
   display: flex;
 }
 
-.breadcrumb-box:after {
+.breadcrumb:after {
   position: absolute; 
 	right: 0;
 	top: 0;
@@ -118,6 +118,14 @@ select:hover {
 
 .find-my-city:hover {
   color: white;
+}
+
+.hamburger {
+  width: 35px;
+  height: 6px;
+  background-color: rgb(126, 126, 126);
+  border-radius: 2.5px;
+  margin: 5px;
 }
 
 .header-nav {
@@ -423,25 +431,8 @@ main {
 
 @media screen and (max-width: 1175px) {
 
-  .search {
-    display: flex;
-  }
-
   .menu-icon {
     display: none;
-  }
-
-  .menu-lines {
-    margin-left: -2rem;
-    margin-right: 1rem;
-  }
-
-  .hamburger {
-    width: 35px;
-    height: 6px;
-    background-color: rgb(126, 126, 126);
-    border-radius: 2.5px;
-    margin: 5.5px 0 0 10.5px;
   }
 }
 

--- a/table-of-contents-style-homepage/styles.css
+++ b/table-of-contents-style-homepage/styles.css
@@ -425,8 +425,6 @@ main {
 
   .search {
     display: flex;
-    position: absolute;
-    right: 2.5rem;
   }
 
   .menu-icon {
@@ -470,10 +468,11 @@ main {
     flex-direction: column;
   }
 
-  .logo-title {
+  .mobile-header {
     align-items: center;
     background-color: black;
     display: flex;
+    justify-content: space-between;
     padding: 0.5rem 1.5rem;
   }
 

--- a/table-of-contents-style-homepage/styles.css
+++ b/table-of-contents-style-homepage/styles.css
@@ -125,7 +125,10 @@ select:hover {
   height: 6px;
   background-color: rgb(126, 126, 126);
   border-radius: 2.5px;
-  margin: 5px;
+}
+
+.hamburger + .hamburger {
+  margin-top: 5px;
 }
 
 .header-nav {
@@ -135,11 +138,8 @@ select:hover {
 }
 
 .header-nav-item {
+  display: flex;
   margin-left: 1rem;
-}
-
-.header-nav-item:first-child {
-  margin-left: 0;
 }
 
 .homepage-link {
@@ -168,6 +168,16 @@ select:hover {
   border: none;
   white-space: nowrap;
   transition: 0.3s color ease-in-out;
+}
+
+.menu-lines {
+  flex-direction: column;
+}
+
+@media screen and (min-width: 1175px) {
+  .menu-lines {
+    display: none;
+  }
 }
 
 header .search input {
@@ -430,7 +440,6 @@ main {
 /* replace menu items with icon */
 
 @media screen and (max-width: 1175px) {
-
   .menu-icon {
     display: none;
   }

--- a/table-of-contents-style-homepage/styles.css
+++ b/table-of-contents-style-homepage/styles.css
@@ -2,11 +2,6 @@ header, main, body {
   font-family: sans-serif;
 }
 
-.h123-reset {
-  margin: 0;
-  padding: 0;
-}
-
 ul,
 li {
   list-style: none;
@@ -23,38 +18,133 @@ a {
   color: #086CDD;
 }
 
-.desktop-header {
+select:hover {
+  color: white;
+  transition: 0.3s color ease-in-out;
+}
+
+/* ************** */
+/* *** HEADER *** */
+
+.about {
+  color: rgb(226, 226, 226);
+}
+
+.about:hover {
+  color: white;
+}
+
+.breadcrumb {
+  background: black;
+  border-bottom-width: 0.1rem;
+  border-color: rgb(126, 126, 126);
+  color: rgb(226, 226, 226);
+  font-family: sans-serif;
+  font-size: 1rem;
+  font-style: none;
+  font-weight: bold;
+  margin-left: 0.5rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.breadcrumb-box {
+  align-items: center;
   display: flex;
-  justify-content: right;
+}
+
+.breadcrumb-box:after {
+  position: absolute; 
+	right: 0;
+	top: 0;
+	width: 50px;
+	height: 100%;
+	line-height: 38px;
+	content: '\2228';
+	text-align: center;
+	color: white;
+	font-size: 1rem;
+	border-left: 1px solid #3C1C78;
+  z-index: -1;
+}
+
+.breadcrumb-box select {
+  background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+}
+
+.description {
+  white-space: nowrap;
+}
+
+@media screen and (max-width: 1400px) {
+  .description {
+    display: none;
+  }
+}
+
+.desktop-header {
+  align-items: center;
+  background-color: black;
   color: #f5f5f5;
+  display: flex;
+  flex-wrap: nowrap;
   font-size: 1.25rem;
   font-weight: bold;
-  background-color: black;
-  height: 6.6rem;
-  overflow-x: hidden; 
-  margin: 0 -0.5rem;
-  overflow-y: hidden;
-  margin-top: -1rem;
-  margin-bottom: 2.25rem;
+  justify-content: space-between;
+  margin: 0 0 2.25rem;
+  padding: 0.5rem 1.5rem;
 }
 
 .desktop-logo {
-  position: absolute;
-  left: .5rem;
-  width: 66px;
-  height: 66px;
-  margin: 1.6rem 0 .4rem 1.25rem;
+  height: 42px;
+  margin-right: 1em;
+  width: 42px;
 }
 
-.little-help-book {
-  position: absolute;
-  left: 1.7rem;
-  font-size: 2rem;
+@media screen and (min-width: 640px) {
+  .desktop-logo {
+    height: 66px;
+    width: 66px;
+  }
+}
+
+.find-help {
+  color: rgb(226, 226, 226);
   white-space: nowrap;
-  margin: 2.45rem 0 0 5.8rem;
+  font-size: 1rem;
 }
 
-a .little-help-book {
+.find-my-city:hover {
+  color: white;
+}
+
+.header-nav {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.header-nav-item {
+  margin-left: 1rem;
+}
+
+.header-nav-item:first-child {
+  margin-left: 0;
+}
+
+.homepage-link {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.homepage-link:hover {
+  cursor: pointer;
+}
+
+.homepage-link .little-help-book {
   color: white;
 }
 
@@ -70,97 +160,6 @@ a .little-help-book {
   border: none;
   white-space: nowrap;
   transition: 0.3s color ease-in-out;
-  margin: 2.8rem .5rem 1.5rem 0;
-}
-
-.breadcrumb-box {
-  margin-left: -4.5rem;
-}
-
-/* We're in the process of adding a caret/down-arrow to the dropdown menu box. */
-
-.breadcrumb-box select {
-  /* hide default arrow */
-  background: transparent;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  /* appearance: button-arrow-down;
-  -webkit-appearance: button-arrow-down;
-  -moz-appearance: button-arrow-down; */
-  /* background-image:
-    linear-gradient(135deg, transparent 80%, black 80%),
-    linear-gradient(45deg, black 80%, transparent 80%),
-    linear-gradient(to right, white, white); */
-}
-
-/* .breadcrumb-box:after {
-  position: absolute; 
-	right: 0;
-	top: 0;
-	width: 50px;
-	height: 100%;
-	line-height: 38px;
-	content: '\2228';
-	text-align: center;
-	color: white;
-	font-size: 1rem;
-	border-left: 1px solid #3C1C78;
-  z-index: -1;
-}  */
-
-.breadcrumb {
-  background: black;
-  border-color: rgb(126, 126, 126);
-  color: rgb(226, 226, 226);
-  font-family: sans-serif;
-  font-size: 1rem;
-  font-style: none;
-  font-weight: bold;
-  height: 2.7rem;
-  width: 14.5rem;
-  border-bottom-width: 0.1rem;
-  margin: 2.6rem 0 0 -0.5rem;
-  margin-right: 0.75rem;
-}
-
-select:hover {
-  color: white;
-  transition: 0.3s color ease-in-out;
-}
-
-.description {
-  white-space: nowrap;
-  margin: 3.14rem -26.5rem 0 0;
-}
-
-.find-help {
-  color: rgb(226, 226, 226);
-  margin: 3.35rem 5.3rem 0 30rem;
-  white-space: nowrap;
-  font-size: 1rem;
-}
-
-.find-my-city:hover {
-  color: white;
-}
-  
-.spanish:hover {
-  color: white;
-}
-
-.about:hover {
-  color: white;
-}
-
-.about {
-  color: rgb(226, 226, 226);
-}
-
-.search {
-  width: 3%;
-  margin: 2.8rem 0 0;
-  padding-right: 4.5rem;
 }
 
 header .search input {
@@ -174,12 +173,94 @@ header .search input {
   border: none;
 }
 
+
+.spanish:hover {
+  color: white;
+}
+
+/* The following styles below are redundant now - flexbox does all the work!
+
+.desktop-header {
+  justify-content: right;
+  height: 6.6rem;
+  overflow-x: hidden; 
+  margin: 0 -0.5rem;
+  overflow-y: hidden;
+  margin-top: -1rem;
+  margin-bottom: 2.25rem;
+}
+
+.desktop-logo {
+  position: absolute;
+  left: .5rem;
+  margin: 1.6rem 0 .4rem 1.25rem;
+}
+
+.little-help-book {
+  position: absolute;
+  left: 1.7rem;
+  margin: 2.45rem 0 0 5.8rem;
+}
+
+a .little-help-book {
+  color: white;
+}
+
+.description {
+  margin: 3.14rem -26.5rem 0 0;
+}
+
+.menu-button {
+  margin: 2.8rem .5rem 1.5rem 0;
+}
+
+.breadcrumb-box {
+  margin-left: -4.5rem;
+}
+
+.breadcrumb {
+  height: 2.7rem;
+  width: 14.5rem;
+  margin: 2.6rem 0 0 -0.5rem;
+  margin-right: 0.75rem;
+}
+
+.find-help {
+  margin: 3.35rem 5.3rem 0 30rem;
+}
+
+.spanish:hover {
+  color: white;
+}
+
+.search {
+  width: 3%;
+  margin: 2.8rem 0 0;
+  padding-right: 4.5rem;
+}
+*/
+
+/* *** END HEADER *** */
+/* ****************** */
+
 body {
   background-color: #f5f5f5;
+  margin: 0;
+  padding: 0;
 }
 
 main {
   columns: 4;
+}
+
+.little-help-book {
+  font-size: 2rem;
+  white-space: nowrap;
+}
+
+.h123-reset {
+  margin: 0;
+  padding: 0;
 }
   
 .table-of-contents {
@@ -338,13 +419,6 @@ main {
   color: #086CDD;
 }
 
-@media screen and (max-width: 1400px) {
-
-  .description {
-    display: none;
-  }
-}
-
 /* replace menu items with icon */
 
 @media screen and (max-width: 1175px) {
@@ -411,13 +485,6 @@ main {
     margin: 0 -0.5rem;
     overflow-y: hidden;
     margin-top: -1rem;
-  }
-
-  img {
-    position: absolute;
-    width: 66px;
-    height: 66px;
-    margin: 1.6rem 0 .4rem 1.75rem;
   }
 
   .little-help-book {
@@ -517,12 +584,6 @@ main {
 
   header {
     height: 5rem;
-  }
-
-  img {
-    width: 42px;
-    height: 42px;
-    margin: 1.49rem 0 .4rem 1.35rem;
   }
 
   .little-help-book {

--- a/table-of-contents-style-homepage/styles.css
+++ b/table-of-contents-style-homepage/styles.css
@@ -470,30 +470,16 @@ main {
     flex-direction: column;
   }
 
-  header {
-    padding-top: 0;
-  }
-
-  header .logo-title {
-    display: flex;
-  }
-
-  header {
+  .logo-title {
+    align-items: center;
     background-color: black;
-    height: 6.6rem;
-    overflow-x: hidden; 
-    margin: 0 -0.5rem;
-    overflow-y: hidden;
-    margin-top: -1rem;
+    display: flex;
+    padding: 0.5rem 1.5rem;
   }
 
   .little-help-book {
-    position: absolute;
     color: white;
     font-size: 2rem;
-    font-weight: bold;
-    font-family: sans-serif;
-    margin: 2.45rem 0 0 5.8rem;
   }
 
   .people-care {
@@ -569,11 +555,7 @@ main {
     display: none;
   }
 
-  header {
-    padding-top: 0;
-  }
-
-  header .logo-title {
+  .logo-title {
     display: flex;
   }
 }
@@ -582,13 +564,8 @@ main {
 
 @media screen and (max-width: 640px) {
 
-  header {
-    height: 5rem;
-  }
-
   .little-help-book {
     font-size: 1.2rem;
-    margin: 2.1rem 0 0 3.7rem;
   }
 
   .people-care {

--- a/table-of-contents-style-homepage/subcategory.css
+++ b/table-of-contents-style-homepage/subcategory.css
@@ -11,10 +11,6 @@ main {
   margin-bottom: 0;
 }
 
-.breadcrumb-box {
-  margin-left: 20rem;
-}
-
 .breadcrumb {
   width: 16.8rem;
 }
@@ -23,24 +19,6 @@ option {
   background-color: white;
   color: black;
   font-size: 1rem;
-}
-
-.search {
-  display: flex;
-}
-
-.menu-lines {
-  margin-left: -0.5rem;
-  margin-right: 1rem;
-  margin-top: -0.1rem;
-}
-
-.hamburger {
-  width: 35px;
-  height: 6px;
-  background-color: rgb(126, 126, 126);
-  border-radius: 2.5px;
-  margin: 5.5px 0 0 10.5px;
 }
 
 .bottom-of-menu {
@@ -198,6 +176,12 @@ option {
 
 /* responsive transition to tablet */
 
+@media screen and (min-width: 1175px) {
+  .menu-lines {
+    display: block;
+  }
+}
+
 @media screen and (max-width: 1056px) {
 
   .mobile-container {
@@ -211,12 +195,6 @@ option {
   body {
     display: flex;
     flex-direction: column-reverse;
-  }
-
-  #search {
-    display: flex;
-    justify-content: right;
-    margin-right: 2.5rem;
   }
 
   .bottom-of-menu {
@@ -247,18 +225,9 @@ option {
   }
 }
   
-  /* begin mobile styles */
+/* begin mobile styles */
   
-  @media screen and (max-width: 640px) {
-
-  #search {
-    margin-right: 1.5rem;
-  }
-
-  .search {
-    margin: 1.5rem 0 0;
-    right: 1.5rem;
-  }
+@media screen and (max-width: 640px) {
 
   .bottom-of-menu {
     margin-left: 2rem;

--- a/table-of-contents-style-homepage/subcategory.html
+++ b/table-of-contents-style-homepage/subcategory.html
@@ -38,11 +38,14 @@
 
     <div class="page-container">
 
-        <header class="desktop-header">
-            <div> <a href="index.html">
-                <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="66px" height="66px">
-                <h1 class="little-help-book">Little Help Book</h1> </a>
-            </div>
+         <header class="desktop-header">
+        	<div class="branding">
+				<a class="homepage-link" href="index.html">
+					<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+					<h1 class="little-help-book">Little Help Book</h1>    
+				</a>
+			</div>
+
             <div class="breadcrumb-box">
                 <select class="breadcrumb city" id="citySelect">
                     <option value=""><em>Loading...</em></option>
@@ -55,16 +58,18 @@
                 </select>
             </div>
     
-            <div class="search">
-                <a href="about.html">
-                <div class="menu-lines">
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>
-                  <div class="hamburger"></div>        
-                </div>
+            <nav class="header-nav">
+                <a class="header-nav-item">
+                    <div class="menu-lines">
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                        <div class="hamburger"></div>
+                    </div>
                 </a>
-                <input type="image" src="search-line.png" class="search-input" type="search">
-            </div>
+                <div class="header-nav-item search">
+                    <input type="image" src="search-line.png" class="search-input" type="search">
+                </div>
+            </nav>
         </header>
 
         <div class="bottom-of-menu">
@@ -133,21 +138,23 @@
     </div>
 
     <div class="mobile-container" id="mobile-container">
-        <header class="logo-title black-top">
-            <img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-            <h1 class="little-help-book">Little Help Book</h1>
-            <div id="search">
-                <div class="search">
-                    <a href="about.html">
-                    <div class="menu-lines">
+        <header class="mobile-header">
+            <div class="branding">
+                <a class="homepage-link" href="index.html">
+                    <img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+                    <h1 class="little-help-book">Little Help Book</h1>
+                </a>
+            </div>
+            <nav class="header-nav">
+                <div class="header-nav-item menu-lines">
                     <div class="hamburger"></div>
                     <div class="hamburger"></div>
-                    <div class="hamburger"></div>        
-                    </div>
-                    </a>
+                    <div class="hamburger"></div>
+                </div>
+                <div class="header-nav-item search">
                     <input type="image" src="search-line.png" class="search-input" type="search">
                 </div>
-            </div>
+            </nav>
         </header>
     </div>
 

--- a/table-of-contents-style-homepage/terms-of-use.html
+++ b/table-of-contents-style-homepage/terms-of-use.html
@@ -26,34 +26,40 @@
 </head>
 <body>
 	<div class="container">
+
 		<header class="desktop-header">
-			<div class="homepage-link">
-				<a href="index.html">
-				<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-				<h1 class="little-help-book">Little Help Book</h1>    
+				<a class="homepage-link" href="index.html">
+						<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+						<h1 class="little-help-book">Little Help Book</h1>
 				</a>
-			</div>
-			<div class="description menu-icon">Human Services Resource Directory</div>
-            <div class="find-help menu-icon">Find help in</div>
 
-			<!-- the new Find my City element is here but the script needed for it to work isn't hooked up -->
-            <div class="breadcrumb-box">
-                <select class="breadcrumb city menu-icon" id="citySelect">
-                    <option value="">Lane County, Oregon</option>
-                </select>
-            </div>
+				<div class="description menu-icon">Human Services Resource Directory</div>
 
-				<button class="spanish menu-button menu-icon">Español</button>
-				<button class="about menu-button menu-icon"><a class="about" href="about.html">About</a></button>
-			<div class="search">
-					<div class="menu-lines">
-					<div class="hamburger"></div>
-					<div class="hamburger"></div>
-					<div class="hamburger"></div>        
-					</div>
-					<input type="image" src="search-line.png" class="search-input" type="search">
-			</div>
+				<!-- Gets filled dynamically -->
+				<div class="breadcrumb-box">
+						<div class="find-help menu-icon">Find help in</div>
+						<select class="breadcrumb city menu-icon" id="citySelect">
+								<option value=""><em>Loading...</em></option>
+								<option value="">Lane County, Oregon</option>
+						</select>
+				</div>
+
+				<nav class="header-nav">
+						<button class="header-nav-item spanish menu-button menu-icon">Español</button>
+						<button class="header-nav-item about menu-button menu-icon"><a class="about" href="about.html">About</a></button>
+						<a class="header-nav-item" href="#">
+								<div class="menu-lines">
+										<div class="hamburger"></div>
+										<div class="hamburger"></div>
+										<div class="hamburger"></div>
+								</div>
+						</a>
+						<div class="header-nav-item search">
+								<input type="image" src="search-line.png" class="search-input" type="search">
+						</div>
+				</nav>
 		</header>
+
 		<main class="about-container">
 		<section class="left-side">
             <div class="about-content">
@@ -110,21 +116,25 @@
 	</div>
 
 	<div class="mobile-container" id="mobile-container">
-		<header class="logo-title black-top">
-				<img src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
-				<h1 class="little-help-book">Little Help Book</h1>
-				<div id="search">
-						<div class="search">
-								<div class="menu-lines">
-								<div class="hamburger"></div>
-								<div class="hamburger"></div>
-								<div class="hamburger"></div>        
-								</div>
-								<input type="image" src="search-line.png" class="search-input" type="search">
-						</div>
-				</div>
-		</header>
-</div>
+			<header class="mobile-header">
+					<div class="branding">
+							<a class="homepage-link" href="index.html">
+									<img class="desktop-logo" src="white-bird-on-black.png" alt="White Bird Clinic" width="42" height="42">
+									<h1 class="little-help-book">Little Help Book</h1>
+							</a>
+					</div>
+					<nav class="header-nav">
+							<div class="header-nav-item menu-lines">
+									<div class="hamburger"></div>
+									<div class="hamburger"></div>
+									<div class="hamburger"></div>
+							</div>
+							<div class="header-nav-item search">
+									<input type="image" src="search-line.png" class="search-input" type="search">
+							</div>
+					</nav>
+			</header>
+	</div>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 <script type="text/javascript" src="homepage.js"></script>
 <script type="text/javascript" src="src/NavBreadcrumb.js"></script>


### PR DESCRIPTION
This PR standardizes header markup and refactors the related styles to fix the overlapping elements shown here:

<img width="1552" alt="Screen Shot 2020-10-15 at 12 46 19 PM" src="https://user-images.githubusercontent.com/1348738/96324489-f30c0000-0fd6-11eb-93cb-2bc2ab6a28dc.png">

"Refactoring" in this case means moving the header styles into one continuous block in `styles.css` for the CSS, and modifying the markup and styles so that flexbox can handle the layout, which makes explicit margins/padding/positioning unnecessary. All pages should have the fixes.

Note: I only did what was necessary to fix the overlapping issue, and I made guesses about what content is intended for the header on each page. After @ArthurSmid checks that the content of each header is correct, I'll make any required changes there.

Also, on pages that have the three select menus (ex. `category.html`), the header doesn't collapse at browser widths between the 1056px breakpoint, and about 1325px. We'll need a solution for that - maybe moving the select menus out of the header, to the top of the page body? Let's discuss and I'll make the necessary changes pre-merge.