### PR TITLE
Remove unnecessary line introduced from search template from all files

### DIFF
--- a/table-of-contents-style-homepage/category.html
+++ b/table-of-contents-style-homepage/category.html
@@ -89,9 +89,7 @@
             <form class="search-form">
                 <div class="search-flexbox" role="search">
                     <div class="search-text-and-button-container">
-                        <label class="search-label" for="search">Type keywords and press Search
-                            <p id="error" role="alert"></p>
-                        </label>
+                        <label class="search-label" for="search">Type keywords and press Search</label>
                         <input class="search-button" type="button" value="Search">
                      </div>
                     <input id="searchInput" class="search-input" type="text">

--- a/table-of-contents-style-homepage/emergency.html
+++ b/table-of-contents-style-homepage/emergency.html
@@ -85,9 +85,7 @@
           <form class="search-form">
               <div class="search-flexbox" role="search">
                   <div class="search-text-and-button-container">
-                      <label class="search-label" for="search">Type keywords and press Search
-                          <p id="error" role="alert"></p>
-                      </label>
+                      <label class="search-label" for="search">Type keywords and press Search</label>
                       <input class="search-button" type="button" value="Search">
                    </div>
                   <input id="searchInput" class="search-input" type="text">

--- a/table-of-contents-style-homepage/index.html
+++ b/table-of-contents-style-homepage/index.html
@@ -82,9 +82,7 @@
             <form class="search-form">
                 <div class="search-flexbox" role="search">
                     <div class="search-text-and-button-container">
-                        <label class="search-label" for="search">Type keywords and press Search
-                            <p id="error" role="alert"></p>
-                        </label>
+                        <label class="search-label" for="search">Type keywords and press Search</label>
                         <input class="search-button" type="button" value="Search">
                      </div>
                     <input id="searchInput" class="search-input" type="text">

--- a/table-of-contents-style-homepage/map.html
+++ b/table-of-contents-style-homepage/map.html
@@ -82,9 +82,7 @@
         <form class="search-form">
             <div class="search-flexbox" role="search">
                 <div class="search-text-and-button-container">
-                    <label class="search-label" for="search">Type keywords and press Search
-                        <p id="error" role="alert"></p>
-                    </label>
+                    <label class="search-label" for="search">Type keywords and press Search</label>
                     <input class="search-button" type="button" value="Search">
                  </div>
                 <input id="searchInput" class="search-input" type="text">

--- a/table-of-contents-style-homepage/provider.html
+++ b/table-of-contents-style-homepage/provider.html
@@ -99,9 +99,7 @@
             <form class="search-form">
                 <div class="search-flexbox" role="search">
                     <div class="search-text-and-button-container">
-                        <label class="search-label" for="search">Type keywords and press Search
-                            <p id="error" role="alert"></p>
-                        </label>
+                        <label class="search-label" for="search">Type keywords and press Search</label>
                         <input class="search-button" type="button" value="Search">
                      </div>
                     <input id="searchInput" class="search-input" type="text">

--- a/table-of-contents-style-homepage/providers.html
+++ b/table-of-contents-style-homepage/providers.html
@@ -82,9 +82,7 @@
             <form class="search-form">
                 <div class="search-flexbox" role="search">
                     <div class="search-text-and-button-container">
-                        <label class="search-label" for="search">Type keywords and press Search
-                            <p id="error" role="alert"></p>
-                        </label>
+                        <label class="search-label" for="search">Type keywords and press Search</label>
                         <input class="search-button" type="button" value="Search">
                      </div>
                     <input id="searchInput" class="search-input" type="text">

--- a/table-of-contents-style-homepage/subcategory.html
+++ b/table-of-contents-style-homepage/subcategory.html
@@ -94,9 +94,7 @@
             <form class="search-form">
                 <div class="search-flexbox" role="search">
                     <div class="search-text-and-button-container">
-                        <label class="search-label" for="search">Type keywords and press Search
-                            <p id="error" role="alert"></p>
-                        </label>
+                        <label class="search-label" for="search">Type keywords and press Search</label>
                         <input class="search-button" type="button" value="Search">
                      </div>
                     <input id="searchInput" class="search-input" type="text">

--- a/table-of-contents-style-homepage/terms-of-use.html
+++ b/table-of-contents-style-homepage/terms-of-use.html
@@ -82,9 +82,7 @@
             <form class="search-form">
                 <div class="search-flexbox" role="search">
                     <div class="search-text-and-button-container">
-                        <label class="search-label" for="search">Type keywords and press Search
-                            <p id="error" role="alert"></p>
-                        </label>
+                        <label class="search-label" for="search">Type keywords and press Search</label>
                         <input class="search-button" type="button" value="Search">
                      </div>
                     <input id="searchInput" class="search-input" type="text">


### PR DESCRIPTION
Remove `<p id="error" role="alert"></p>` from all files where it still exists. #178 

This line had been introduce from [an a11y article](https://www.a11ymatters.com/pattern/accessible-search/) that has a code template for accessible searches. It was introduced with the idea that the search would be extended to handle errors. However the existing search works fine, so remove this extraneous line.

- [x] index.html
- [x] category.html
- [x] subcategory.html
- [x] provider.html
- [x] map.html
- [x] emergency.html
- [x] providers.html
- [x] terms-of-use.html

Note: This code was removed from about.html in a prior PR. #179 