### PR TITLE
Make color of Search button contrast with background

### DIFF
--- a/table-of-contents-style-homepage/styles.css
+++ b/table-of-contents-style-homepage/styles.css
@@ -693,7 +693,7 @@ main {
 }
 
 .search-button {
-  background: #4A9AF8;
+  background: #0870E7;
   color: #fff;
   border: 0;
   appearance: none;


### PR DESCRIPTION
Change `.search-button {}` in style.css so that the color of the button in the foreground is a high enough contrast with the white background as to meet WCAG color contrast standard of 4.5:1 minimum. This color change affects all .html files because the Search button is in the header on all .html pages.